### PR TITLE
Minor tweaks for OS X

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ are not experienced with the command line and debugging on your own.
 ### Supported Environments
 * Linux
 * Windows + Git Bash ([#3](https://github.com/steamguard-totp/steamguard-shared-secret/issues/3))
-* Maybe Mac (untested)
+* Mac (`brew install apktool; brew cask install android-platform-tools`)
 
 # How it does it
 If you phone is rooted, don't use this. Do this instead:

--- a/get_code.sh
+++ b/get_code.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+command -v "python2"
+if [[ $? -ne 0 ]]; then
+    printf 'Missing python2. Installed under a different name?\n'
+    exit 1
+fi
+
 # Abort on errors.
 set -e
 

--- a/get_code.sh
+++ b/get_code.sh
@@ -15,7 +15,12 @@ locked out of your Steam account!
 read -rp 'Press [ENTER] when you are ready, or Ctrl-C to exit.'
 
 printf '[ Pulling APK from device ]\n'
-adb pull /data/app/com.valvesoftware.android.steam.community-1/base.apk steam.apk
+adb shell pm list packages \
+    | grep -m1 steam.community \
+    | cut -d: -f2 \
+    | xargs -r -n1 -I@ adb shell pm path @ \
+    | cut -d: -f2 \
+    | xargs -r -n1 -I@ adb pull @ steam.apk
 
 printf '\n[ Disassembling APK ]\n'
 apktool d steam.apk

--- a/get_code.sh
+++ b/get_code.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Abort on errors.
+set -e
+
 printf 'Make sure Steam Guard Mobile Authenticator is DISABLED or you will be
 locked out of your Steam account!
 '

--- a/get_code.sh
+++ b/get_code.sh
@@ -34,7 +34,7 @@ apktool b steam
 
 printf '\n[ Generating signing key ]\n'
 STOREPASS=$(tr -dc 'a-zA-Z0-9' < /dev/urandom | fold -w 32 | head -n 1)
-KEYPASS=$(tr -dc 'a-zA-Z0-9' < /dev/urandom | fold -w 32 | head -n 1)
+KEYPASS="$STOREPASS"
 keytool -genkey -noprompt \
     -keyalg RSA \
     -keysize 2048 \

--- a/get_code.sh
+++ b/get_code.sh
@@ -74,4 +74,4 @@ Extracting data. Please confirm "back up my data" on device. DO NOT set a passwo
 adb backup -f backup.ab com.valvesoftware.android.steam.community
 dd if=backup.ab bs=24 skip=1 | python2 -c "import zlib,sys;sys.stdout.write(zlib.decompress(sys.stdin.read()))" | tar -xf -
 
-cat apps/com.valvesoftware.android.steam.community/f/*
+cat apps/com.valvesoftware.android.steam.community/f/* | python2 -m json.tool


### PR DESCRIPTION
Thanks a lot for the script! This was a really slick breakdown and an easy way to get the secret without root. Now I can use my favorite 2FA app for Steam too.

I ran it on OS X and it worked as you guessed it probably would. I had to make a few tweaks for it to run all the way through. I'm not sure if they're specific to Mac or just changes to the Steam app and `keytool`/`jarsigner` that have happened in the months since the script was first written.

Feel free to accept only some (or none) of these changes if you think they might complicate it running on other systems. I included rationale for each change in the individual commit messages.

Thanks again for the script!